### PR TITLE
Extend templates endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Here are some examples where gns3fy is used in a programmatic way:
 
 - [Ansible-collection-gns3](https://galaxy.ansible.com/davidban77/gns3): Useful for CI/CD pipelines to interact with GNS3 server using Ansible. It can create/delete projects, nodes and links in an ansible playbook.
 - Terraform: Soming soon... (although it might be a Go version of it)
+- [Migrate templates between GNS3 servers](https://davidban77.github.io/gns3fy/user-guide/#migrate-templates-between-gns3-servers)
 
 ## Install
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -10,6 +10,8 @@ Here are some examples where gns3fy is used in a programmatic way:
 
 - [Ansible-collection-gns3](https://galaxy.ansible.com/davidban77/gns3): Useful for CI/CD pipelines to interact with GNS3 server using Ansible. It can create/delete projects, nodes and links in an ansible playbook.
 
+- [Migrate templates between GNS3 servers](user-guide.md#migrate-templates-between-gns3-servers)
+
 ## Install
 
 ```

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -525,3 +525,70 @@ Frame Relay switch  dd0f6f3a-ba58-3249-81cb-a1dd88407a47  frame_relay_switch  Tr
 ATM switch          aaa764e2-b383-300f-8a0e-3493bbfdb7d2  atm_switch          True       N/A        switch
 """
 ```
+
+### Migrate templates between GNS3 servers
+
+You may need to backup your current templates configuration of one server to another, or just want to standardize the templates used across your GNS3 server.
+
+Here is a simple script that shows an example of how to achive it with `Gns3Connector`.
+
+`migrate_gns3_templates.py`
+
+```python
+from gns3fy import Gns3Connector
+
+OLD_URL = "http://gns3server01:3080"
+NEW_URL = "http://gns3server02:3080"
+
+def main()
+    # Define the server objects
+    old_server = Gns3Connector(url=OLD_URL)
+    new_server = Gns3Connector(url=NEW_URL)
+
+    # Retrive their current templates
+    old_server_templates = old_server.get_templates()
+    new_server_templates = new_server.get_templates()
+
+    # Now pass the templates
+    for template in old_server_templates:
+        # Bypass templates already configured on new server
+        if any(template["name"] == x["name"] for x in new_server_templates):
+            print(f"Template: {template['name']} already present. Skipping...")
+            continue
+
+        # Pass template
+        new_server.create_template(**template)
+        print(f"Template: {template['name']} passed!")
+
+if __name__ == '__main__':
+    main()
+```
+
+It can produce an output similar to this:
+
+`python migrate_gns3_templates.py`
+
+```
+Template: vEOS-4.21.5F passed!
+Template: Junos vMX passed!
+Template: alpine passed!
+Template: Cloud already present. Skipping...
+Template: NAT already present. Skipping...
+Template: VPCS already present. Skipping...
+Template: Ethernet switch already present. Skipping...
+Template: Ethernet hub already present. Skipping...
+Template: Frame Relay switch already present. Skipping...
+Template: ATM switch already present. Skipping...
+Template: netautomator passed!
+Template: Cisco IOSv 15.7(3)M3 passed!
+Template: Cisco IOSvL2 15.2.1 passed!
+Template: Cisco IOSvL2 15.2(20170321:233949) passed!
+Template: Cisco IOS XRv 9000 6.5.1 passed!
+Template: Cisco IOS XRv 6.1.3 passed!
+Template: Cisco NX-OSv 7.3.0 passed!
+Template: Cisco ASAv 9.9.2 passed!
+Template: Cisco CSR1000v 16.9.4 passed!
+Template: Cumulus VX 3.7.8 passed!
+Template: Cisco NX-OSv 9000 7.0.3.I7.4 passed!
+Template: Arista vEOS 4.21.5F passed!
+```

--- a/gns3fy/gns3fy.py
+++ b/gns3fy/gns3fy.py
@@ -262,6 +262,68 @@ class Gns3Connector:
         else:
             raise ValueError("Must provide either a name or template_id")
 
+    def update_template(self, name=None, template_id=None, **kwargs):
+        """
+        Updates a template by giving its name or UUID. For more information [API INFO]
+        (http://api.gns3.net/en/2.2/api/v2/controller/template/
+        templatestemplateid.html#put-v2-templates-template-id)
+
+        **Required Attributes:**
+
+        - `name` or `template_id`
+        """
+        _template = self.get_template(name=name, template_id=template_id)
+        _template.update(**kwargs)
+
+        response = self.http_call(
+            "put",
+            url=f"{self.base_url}/templates/{_template['template_id']}",
+            json_data=_template,
+        )
+
+        return response.json()
+
+    def create_template(self, **kwargs):
+        """
+        Creates a template by giving its attributes. For more information [API INFO]
+        (http://api.gns3.net/en/2.2/api/v2/controller/template/
+        templates.html#post-v2-templates)
+
+        **Required Attributes:**
+
+        - `name`
+        - `compute_id` by default is 'local'
+        - `template_type`
+        """
+        _template = self.get_template(name=kwargs["name"])
+        if _template:
+            raise ValueError(f"Template already used: {kwargs['name']}")
+
+        if "compute_id" not in kwargs:
+            kwargs["compute_id"] = "local"
+
+        response = self.http_call(
+            "post", url=f"{self.base_url}/templates", json_data=kwargs
+        )
+
+        return response.json()
+
+    def delete_template(self, name=None, template_id=None):
+        """
+        Deletes a template by giving its attributes. For more information [API INFO]
+        (http://api.gns3.net/en/2.2/api/v2/controller/template/
+        templatestemplateid.html#id16)
+
+        **Required Attributes:**
+
+        - `name` or `template_id`
+        """
+        if name and not template_id:
+            _template = self.get_template(name=name)
+            template_id = _template["template_id"]
+
+        self.http_call("delete", url=f"{self.base_url}/templates/{template_id}")
+
     def get_nodes(self, project_id):
         """
         Retieves the nodes defined on the project

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -273,9 +273,7 @@ class Gns3ConnectorMock(Gns3Connector):
             status_code=404,
         )
         self.adapter.register_uri(
-            "DELETE",
-            f"{self.base_url}/templates/{CTEMPLATE['id']}",
-            status_code=204,
+            "DELETE", f"{self.base_url}/templates/{CTEMPLATE['id']}", status_code=204
         )
         ############
         # Projects #


### PR DESCRIPTION
Added tests and docs for it as with an example of migrating templates between GNS3 servers.

Closes #41 