### PR TITLE
Adding snapshots funcionality

### DIFF
--- a/docs/content/about/changelog.md
+++ b/docs/content/about/changelog.md
@@ -12,10 +12,15 @@ pip install -U gns3fy
 
 - Extended templates functionality with `create_template`, `update_template` and `delete_template`. Which can be used for migrating templates between GNS3 servers
 
-- Added compute endpoint get method from the REST API:
+- Added compute endpoint get method from the REST API. [Compute endpoint](http://api.gns3.net/en/2.2/api/v2/controller/compute.html)
     - `get_computes`: Retrieves attributes and characteristics of the GNS3 server compute that will run the emulations.
     - `get_compute_images`: Lists images configured for a specific emulator on a compute.
     - `get_compute_ports`: Lists configured and used console ports and UDP ports on a compute.
+
+- Added projects snapshots attribute and methods. [Snapshots endpoint](http://api.gns3.net/en/2.2/api/v2/controller/snapshot.html)
+    - `snapshots`: Attribute that stores snapshots names, IDs and created times of a project. Updated by the `get_snapshots` method.
+    - `get_snapshot`: Retrieves an specific snapshot information.
+    - `create_snapshot` and `delete_snapshot`: Creates/Delete an specific snapshot
 
 ## 0.4.1
 

--- a/docs/content/api_reference.md
+++ b/docs/content/api_reference.md
@@ -970,6 +970,8 @@ Returns the Node object by searching for the `name` or the `node_id`.
 
 - `project_id`
 - `connector`
+
+**Required keyword arguments:**
 - `name` or `node_id`
 
 **NOTE:** Run method `get_nodes()` manually to refresh list of nodes if
@@ -1032,4 +1034,67 @@ port)
 - `node_b`: Node name of the B side
 - `port_b`: Port name of the B side (must match the `name` attribute of the
 port)
+
+### `Project.get_snapshots()`
+
+```python
+def get_snapshots(self)
+```
+
+Retrieves list of snapshots of the project
+
+**Required Project instance attributes:**
+
+- `project_id`
+- `connector`
+
+### `Project.get_snapshot()`
+
+```python
+def get_snapshot(self, name=None, snapshot_id=None)
+```
+
+Returns the Snapshot by searching for the `name` or the `snapshot_id`.
+
+**Required Attributes:**
+
+- `project_id`
+- `connector`
+
+**Required keyword arguments:**
+- `name` or `snapshot_id`
+
+### `Project.create_snapshot()`
+
+```python
+def create_snapshot(self, name)
+```
+
+Creates a snapshot of the project
+
+**Required Project instance attributes:**
+
+- `project_id`
+- `connector`
+
+**Required keyword aguments:**
+
+- `name`
+
+### `Project.delete_snapshot()`
+
+```python
+def delete_snapshot(self, snapshot_id)
+```
+
+Deletes a snapshot of the project
+
+**Required Project instance attributes:**
+
+- `project_id`
+- `connector`
+
+**Required keyword aguments:**
+
+- `snapshot_id`
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -633,3 +633,38 @@ else:
         f" Memory avg: {mem_avg}%"
     )
 ```
+
+### Create and list project snapshots
+
+There is an attribute called `snapshots` under the `Project` instance, which stores snapshots information about that project.
+
+You can create, delete and also search for specific snapshots of a project. See the [API reference](api_reference.md#projectget_snapshots)
+
+Here is a snippet that creates and shows information about the snapshots configured on a project.
+
+```python
+from datetime import datetime
+from gns3fy import Gns3Connector, Project
+
+lab = Project(name="test3", connector=Gns3Connector(url="http://gns3server01:3080"))
+
+lab.get()
+
+# Create snapshot
+lab.create_snapshot(name="snap3")
+
+# Show configured snapshots
+for snapshot in lab.snapshots:
+    _time = datetime.utcfromtimestamp(snapshot['created_at']).strftime('%Y-%m-%d %H:%M:%S')
+    print(f"Snapshot: {snapshot['name']}, created at: {_time}")
+```
+
+It prints something similar to this:
+
+```
+Created snapshot: snap3
+
+Snapshot: snap1, created at: 2019-09-28 20:59:50
+Snapshot: snap2, created at: 2019-09-28 20:59:54
+Snapshot: snap3, created at: 2019-09-29 08:44:28
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,7 +289,7 @@ description = "Toolbox with useful Python classes and type magic."
 name = "nr.types"
 optional = false
 python-versions = "*"
-version = "2.5.5"
+version = "3.1.0"
 
 [package.dependencies]
 six = "*"
@@ -416,6 +416,7 @@ six = ">=0.11.0"
 reference = "468cace9378a64a267848c07c21a5aedbfab2cf3"
 type = "git"
 url = "https://github.com/NiklasRosenstein/pydoc-markdown.git"
+
 [[package]]
 category = "dev"
 description = "passive checker of Python programs"
@@ -644,7 +645,7 @@ mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "d
 mkdocs = ["17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939", "8cc8b38325456b9e942c981a209eaeb1e9f3f77b493ad755bfef889b9c8d356a"]
 mkdocs-cinder = ["0623b3b8c3a70fb735e966da805ff6f33e6c547ae9b26e6146d4995053e182f5", "984ba6df20916240647e5386d8444e6dbf3a8200e4d6db2d58cb145f40f99ff2"]
 more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-"nr.types" = ["18e083324d77d74f889fd8ca6b57586a85157d8eb2b3930d04a67ab524e86c9a"]
+"nr.types" = ["0a01cc2e29bc7df3925bbc7bcd8bddd171ff77d39fcd479a314ff751ca5989c8"]
 packaging = ["a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9", "c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"]
 parso = ["63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc", "666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"]
 pexpect = ["2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1", "9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"]

--- a/tests/data/project_snapshots.json
+++ b/tests/data/project_snapshots.json
@@ -1,0 +1,14 @@
+[
+    {
+        "created_at": 1569707990,
+        "name": "snap1",
+        "project_id": "4b21dfb3-675a-4efa-8613-2f7fb32e76fe",
+        "snapshot_id": "7fb725fd-efbf-4e90-a259-95f12addf5a2"
+    },
+    {
+        "created_at": 1569707994,
+        "name": "snap2",
+        "project_id": "4b21dfb3-675a-4efa-8613-2f7fb32e76fe",
+        "snapshot_id": "44e08d78-0ee4-4b8f-bad4-117aa67cb759"
+    }
+]

--- a/tests/data/projects.py
+++ b/tests/data/projects.py
@@ -6,7 +6,7 @@ PROJECTS_REPR = [
         "auto_open=False, drawing_grid_size=25, grid_size=75, scene_height=1000, "
         "scene_width=2000, show_grid=True, show_interface_labels=False, show_layers="
         "False, snap_to_grid=False, supplier=None, variables=None, zoom=100, stats="
-        "None)"
+        "None, snapshots=None)"
     ),
     (
         "Project(name='API_TEST', project_id='4b21dfb3-675a-4efa-8613-2f7fb32e76fe', "
@@ -15,6 +15,6 @@ PROJECTS_REPR = [
         "auto_open=False, drawing_grid_size=25, grid_size=75, scene_height=1000, "
         "scene_width=2000, show_grid=False, show_interface_labels=False, show_layers="
         "False, snap_to_grid=False, supplier=None, variables=None, zoom=100,"
-        " stats=None)"
+        " stats=None, snapshots=None)"
     ),
 ]


### PR DESCRIPTION
**New features:**

- Extended templates functionality with `create_template`, `update_template` and `delete_template`. Which can be used for migrating templates between GNS3 servers

- Added compute endpoint get method from the REST API. [Compute endpoint](http://api.gns3.net/en/2.2/api/v2/controller/compute.html)
    - `get_computes`: Retrieves attributes and characteristics of the GNS3 server compute that will run the emulations.
    - `get_compute_images`: Lists images configured for a specific emulator on a compute.
    - `get_compute_ports`: Lists configured and used console ports and UDP ports on a compute.

- Added projects snapshots attribute and methods. [Snapshots endpoint](http://api.gns3.net/en/2.2/api/v2/controller/snapshot.html)
    - `snapshots`: Attribute that stores snapshots names, IDs and created times of a project. Updated by the `get_snapshots` method.
    - `get_snapshot`: Retrieves an specific snapshot information.
    - `create_snapshot` and `delete_snapshot`: Creates/Delete an specific snapshot