### PR TITLE
Enhance link match with test_error_delete_link_with_invalid_param Methods and live tests passed 

### DIFF
--- a/gns3fy/gns3fy.py
+++ b/gns3fy/gns3fy.py
@@ -1758,17 +1758,13 @@ class Project:
                     node_id=_node_a.node_id,
                     adapter_number=_port_a["adapter_number"],
                     port_number=_port_a["port_number"],
-                    label=dict(
-                        text=_port_a["name"],
-                    ),
+                    label=dict(text=_port_a["name"]),
                 ),
                 dict(
                     node_id=_node_b.node_id,
                     adapter_number=_port_b["adapter_number"],
                     port_number=_port_b["port_number"],
-                    label=dict(
-                        text=_port_b["name"],
-                    ),
+                    label=dict(text=_port_b["name"]),
                 ),
             ],
         )
@@ -1776,6 +1772,71 @@ class Project:
         _link.create()
         self.links.append(_link)
         print(f"Created Link-ID: {_link.link_id} -- Type: {_link.link_type}")
+
+    def delete_link(self, node_a, port_a, node_b, port_b):
+        """
+        Deletes  a link.
+
+        **Required Attributes:**
+
+        - `project_id`
+        - `connector`
+        - `node_a`: Node name of the A side
+        - `port_a`: Port name of the A side (must match the `name` attribute of the
+        port)
+        - `node_b`: Node name of the B side
+        - `port_b`: Port name of the B side (must match the `name` attribute of the
+        port)
+        """
+        if not self.nodes:
+            self.get_nodes()
+        if not self.links:
+            self.get_links()
+
+        # checking link info
+        _node_a = self.get_node(name=node_a)
+        if not _node_a:
+            raise ValueError(f"node_a: {node_a} not found")
+        try:
+            _port_a = [_p for _p in _node_a.ports if _p["name"] == port_a][0]
+        except IndexError:
+            raise ValueError(f"port_a: {port_a} not found")
+
+        _node_b = self.get_node(name=node_b)
+        if not _node_b:
+            raise ValueError(f"node_b: {node_b} not found")
+        try:
+            _port_b = [_p for _p in _node_b.ports if _p["name"] == port_b][0]
+        except IndexError:
+            raise ValueError(f"port_b: {port_b} not found")
+
+        _matches = []
+        for _l in self.links:
+            if not _l.nodes:
+                continue
+            if (
+                _l.nodes[0]["node_id"] == _node_a.node_id
+                and _l.nodes[0]["adapter_number"] == _port_a["adapter_number"]
+                and _l.nodes[0]["port_number"] == _port_a["port_number"]
+            ):
+                _matches.append(_l)
+            elif (
+                _l.nodes[1]["node_id"] == _node_b.node_id
+                and _l.nodes[1]["adapter_number"] == _port_b["adapter_number"]
+                and _l.nodes[1]["port_number"] == _port_b["port_number"]
+            ):
+                _matches.append(_l)
+        if not _matches:
+            raise ValueError(f"Link not found: {node_a, port_a, node_b, port_b}")
+
+            # now to delete the link via GNS3_api
+        _link = _matches[0]
+        self.links.remove(_link)
+        _link_id = _link.link_id
+        _link.delete()
+        print(
+            f"Deleted Link-ID: {_link_id} From node {node_a }, port: {port_a} <-->  to node {node_b}, port: {port_b} "
+        )
 
     @verify_connector_and_id
     def get_snapshots(self):

--- a/gns3fy/gns3fy.py
+++ b/gns3fy/gns3fy.py
@@ -1818,24 +1818,16 @@ class Project:
                 _l.nodes[0]["node_id"] == _node_a.node_id
                 and _l.nodes[0]["adapter_number"] == _port_a["adapter_number"]
                 and _l.nodes[0]["port_number"] == _port_a["port_number"]
-                and _l.nodes[1]["node_id"] == _node_b.node_id
+            ):
+                _matches.append(_l)
+            elif (
+                _l.nodes[1]["node_id"] == _node_b.node_id
                 and _l.nodes[1]["adapter_number"] == _port_b["adapter_number"]
                 and _l.nodes[1]["port_number"] == _port_b["port_number"]
             ):
                 _matches.append(_l)
-            elif (
-                _l.nodes[1]["node_id"] == _node_a.node_id
-                and _l.nodes[1]["adapter_number"] == _port_a["adapter_number"]
-                and _l.nodes[1]["port_number"] == _port_a["port_number"]
-                and _l.nodes[0]["node_id"] == _node_b.node_id
-                and _l.nodes[0]["adapter_number"] == _port_b["adapter_number"]
-                and _l.nodes[0]["port_number"] == _port_b["port_number"]
-            ):
-                _matches.append(_l)
         if not _matches:
-            raise ValueError(
-                f"Link not found: {node_a}: {port_a} <===> {node_b}: {port_b}"
-            )
+            raise ValueError(f"Link not found: {node_a, port_a, node_b, port_b}")
 
             # now to delete the link via GNS3_api
         _link = _matches[0]

--- a/tests/test_gns3fy.py
+++ b/tests/test_gns3fy.py
@@ -1467,6 +1467,33 @@ class TestProject:
         with pytest.raises(ValueError, match=expected):
             api_test_project.create_link(*link)
 
+    @pytest.mark.parametrize(
+        "link,expected",
+        [
+            (
+                ("IOU1", "Ethernet77/1", "vEOS", "Ethernet2"),
+                "port_a: Ethernet77/1 not found",
+            ),
+            (
+                ("IOU1", "Ethernet1/1", "vEOS", "Ethernet77"),
+                "port_b: Ethernet77 not found",
+            ),
+            (
+                ("IOU77", "Ethernet1/1", "vEOS", "Ethernet2"),
+                "node_a: IOU77 not found",
+            ),
+            (
+                ("IOU1", "Ethernet1/1", "vEOS77", "Ethernet2"),
+                "node_b: vEOS77 not found",
+            ),
+        ],
+    )
+    def test_error_delete_link_with_invalid_param(
+        self, api_test_project, link, expected
+    ):
+        with pytest.raises(ValueError, match=expected):
+            api_test_project.delete_link(*link)
+
     def test_get_file(self, api_test_project):
         text_data = api_test_project.get_file(path="README.txt")
         assert "This is a README" in text_data

--- a/tests/test_gns3fy.py
+++ b/tests/test_gns3fy.py
@@ -436,6 +436,11 @@ class Gns3ConnectorMock(Gns3Connector):
             f"{self.base_url}/projects/{CPROJECT['id']}/drawings/{CDRAWING['id']}",
             status_code=204,
         )
+        self.adapter.register_uri(
+            "DELETE",
+            f"{self.base_url}/projects/{CPROJECT['id']}/links/NEW_LINK_ID",
+            status_code=204,
+        )
         # Extra project
         self.adapter.register_uri(
             "GET",
@@ -1428,6 +1433,13 @@ class TestProject:
         link = api_test_project.get_link(link_id="NEW_LINK_ID")
         assert link.link_id == "NEW_LINK_ID"
         assert link.link_type == "ethernet"
+
+    def test_delete_link(self, api_test_project):
+        api_test_project.links = []
+        api_test_project.create_link("IOU1", "Ethernet1/1", "vEOS", "Ethernet2")
+        link = api_test_project.get_link(link_id="NEW_LINK_ID")
+        api_test_project.delete_link("IOU1", "Ethernet1/1", "vEOS", "Ethernet2")
+        assert api_test_project.get_link(link_id="NEW_LINK_ID") is None
 
     @pytest.mark.parametrize(
         "link,expected",


### PR DESCRIPTION
All tests passed

Live  tests:

```
In [12]: print(tabulate(links_summary, headers=["Node A", "Port A", "Node B", "Port B"]))
Node A            Port A       Node B            Port B
----------------  -----------  ----------------  -----------
PC-1              Ethernet0    Ethernetswitch-1  Ethernet0
Ethernetswitch-1  Ethernet1    PC-2              Ethernet0
Ethernetswitch-1  Ethernet5    vEOS-4.21.5F-2    Management
IOU1              Ethernet0/0  Ethernetswitch-1  Ethernet2
inet0-VMNET1      eth0         Ethernetswitch-1  Ethernet3
switch2           Ethernet1    IOU2              Ethernet0/0
switch2           Ethernet0    Ethernetswitch-1  Ethernet4

In [13]: first_lab.delete_link('switch2','Ethernet0','Ethernetswitch-1','Ethernet4')
Deleted Link-ID: d2ede188-693d-4e32-9a18-d6cd23d019d7 From node switch2, port: Ethernet0 <-->  to node Ethernetswitch-1, port: Ethernet4

In [14]: first_lab.get()

In [15]: links_summary = first_lab.links_summary(is_print=False)

In [16]: print(tabulate(links_summary, headers=["Node A", "Port A", "Node B", "Port B"]))
Node A            Port A       Node B            Port B
----------------  -----------  ----------------  -----------
PC-1              Ethernet0    Ethernetswitch-1  Ethernet0
Ethernetswitch-1  Ethernet1    PC-2              Ethernet0
Ethernetswitch-1  Ethernet5    vEOS-4.21.5F-2    Management
IOU1              Ethernet0/0  Ethernetswitch-1  Ethernet2
inet0-VMNET1      eth0         Ethernetswitch-1  Ethernet3
switch2           Ethernet1    IOU2              Ethernet0/0
switch2           Ethernet0    Ethernetswitch-1  Ethernet4

In [17]: first_lab.delete_link('Ethernetswitch-1','Ethernet4','switch2','Ethernet0')
Deleted Link-ID: 694e6681-afb3-4bc0-9d8d-6c31bee570b8 From node Ethernetswitch-1, port: Ethernet4 <-->  to node switch2, port: Ethernet0

In [18]: first_lab.get()

In [19]: links_summary = first_lab.links_summary(is_print=False)

In [20]: print(tabulate(links_summary, headers=["Node A", "Port A", "Node B", "Port B"]))
Node A            Port A       Node B            Port B
----------------  -----------  ----------------  -----------
PC-1              Ethernet0    Ethernetswitch-1  Ethernet0
Ethernetswitch-1  Ethernet1    PC-2              Ethernet0
Ethernetswitch-1  Ethernet5    vEOS-4.21.5F-2    Management
IOU1              Ethernet0/0  Ethernetswitch-1  Ethernet2
inet0-VMNET1      eth0         Ethernetswitch-1  Ethernet3
switch2           Ethernet1    IOU2              Ethernet0/0
switch2           Ethernet0    Ethernetswitch-1  Ethernet4

In [21]: first_lab.delete_link('Ethernetswitch-8','Ethernet4','switch2','Ethernet0')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-21-d854dc7da484> in <module>
----> 1 first_lab.delete_link('Ethernetswitch-8','Ethernet4','switch2','Ethernet0')

~/workspace/gns3fy/gns3fy/gns3fy.py in delete_link(self, node_a, port_a, node_b, port_b)
   1797         _node_a = self.get_node(name=node_a)
   1798         if not _node_a:
-> 1799             raise ValueError(f"node_a: {node_a} not found")
   1800         try:
   1801             _port_a = [_p for _p in _node_a.ports if _p["name"] == port_a][0]

ValueError: node_a: Ethernetswitch-8 not found

In [22]: first_lab.delete_link('Ethernetswitch-1','Ethernet4','switch2','Ethernet8')
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
~/workspace/gns3fy/gns3fy/gns3fy.py in delete_link(self, node_a, port_a, node_b, port_b)
   1808         try:
-> 1809             _port_b = [_p for _p in _node_b.ports if _p["name"] == port_b][0]
   1810         except IndexError:

IndexError: list index out of range

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-22-c4366e719bef> in <module>
----> 1 first_lab.delete_link('Ethernetswitch-1','Ethernet4','switch2','Ethernet8')

~/workspace/gns3fy/gns3fy/gns3fy.py in delete_link(self, node_a, port_a, node_b, port_b)
   1809             _port_b = [_p for _p in _node_b.ports if _p["name"] == port_b][0]
   1810         except IndexError:
-> 1811             raise ValueError(f"port_b: {port_b} not found")
   1812 
   1813         _matches = []

ValueError: port_b: Ethernet8 not found
```