### PR TITLE
Proposed Fix for Issue #107

### DIFF
--- a/gns3fy/gns3fy.py
+++ b/gns3fy/gns3fy.py
@@ -651,7 +651,7 @@ class Link:
         data = {
             k: v
             for k, v in self.__dict__.items()
-            if k not in ("connector", "__initialised__")
+            if k not in ("connector", "__initialised__", "__pydantic_initialised__")
             if v is not None
         }
 
@@ -1012,6 +1012,7 @@ class Node:
                 "links",
                 "connector",
                 "__initialised__",
+                 "__pydantic_initialised__",
             )
             if v is not None
         }

--- a/gns3fy/gns3fy.py
+++ b/gns3fy/gns3fy.py
@@ -1012,7 +1012,7 @@ class Node:
                 "links",
                 "connector",
                 "__initialised__",
-                 "__pydantic_initialised__",
+                "__pydantic_initialised__",
             )
             if v is not None
         }
@@ -1258,7 +1258,7 @@ class Project:
         data = {
             k: v
             for k, v in self.__dict__.items()
-            if k not in ("stats", "nodes", "links", "connector", "__initialised__")
+            if k not in ("stats", "nodes", "links", "connector", "__initialised__", "__pydantic_initialised__")
             if v is not None
         }
 


### PR DESCRIPTION
Hi,

there is an incompatibility with recent versions of pydantic, as already pointed out in #107 that completely breaks the library. An additional key must be filtered from request data in various places.
